### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/dockerfiles/part2/e2.4/load-balancer/Dockerfile
+++ b/dockerfiles/part2/e2.4/load-balancer/Dockerfile
@@ -1,3 +1,3 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:v0.9.0
 
 EXPOSE 80


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`